### PR TITLE
Remove initialization of CXXFLAGS, LDFLAGS and  INCLUDES from configure.in.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -45,9 +45,6 @@ AC_LANG_CPLUSPLUS
 dnl ------------------------------------------------------------------
 dnl Initialization for variables
 dnl ------------------------------------------------------------------
-CXXFLAGS="${ac_save_CXXFLAGS}"
-LDFLAGS="${ac_save_LDFLAGS}"
-INCLUDES="${ac_save_INCLUDES}"
 BOOST_INCLUDES=""
 BOOST_LDFLAGS=""
 BOOST_POSTFIX=""


### PR DESCRIPTION
  This fixes configuring with a help of environment variables.